### PR TITLE
minor fix in haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -8,6 +8,6 @@
  "releasenote": "Pre-alpha release",
  "contributors": ["larsiusprime"],
  "dependencies": { 
-  "openfl": "",
+  "openfl": ""
  }
 }


### PR DESCRIPTION
Removed superfluous comma. 
I get a build error due to invalid JSON in JSONParser.hx when using crashdumper with HaxeUI
