### PR TITLE
Prevent pushing data to server if no url is given

### DIFF
--- a/crashdumper/CrashDumper.hx
+++ b/crashdumper/CrashDumper.hx
@@ -77,7 +77,7 @@ class CrashDumper
 	 * @param	stage_				(flash target only) the root Stage object
 	 */
 	
-	public function new(sessionId_:String, ?path_:String, ?url_:String="http://localhost:8080/result", closeOnCrash_:Bool = true, ?customDataMethod_:CrashDumper->Void, ?postCrashMethod_:CrashDumper->Void, ?stage_:Dynamic) 
+	public function new(sessionId_:String, ?path_:String="./", ?url_:String="http://localhost:8080/result", closeOnCrash_:Bool = true, ?customDataMethod_:CrashDumper->Void, ?postCrashMethod_:CrashDumper->Void, ?stage_:Dynamic) 
 	{
 		hook = Util.platform();
 		
@@ -184,7 +184,7 @@ class CrashDumper
 		CACHED_STACK_TRACE = getStackTrace();
 		
 		#if !flash
-			doErrorStuff(e);		//easy to separately override
+			doErrorStuff(e, path != null, url != null && url != "");		//easy to separately override
 		#else
 			doErrorStuffByHTTP(e);	//minimal flash error report
 		#end
@@ -262,7 +262,8 @@ class CrashDumper
 					f.close();
 					
 					var sanityCheck:String = File.getContent(path + pathLogErrors + logdir + "_error.txt");
-					
+					trace("Dumpfile saved: \n" + FileSystem.fullPath(uniqueErrorLogPath+ "_error.txt"));
+
 					//write out all our associated game session files
 					for (filename in session.files.keys())
 					{

--- a/crashdumper/CrashDumper.hx
+++ b/crashdumper/CrashDumper.hx
@@ -184,7 +184,7 @@ class CrashDumper
 		CACHED_STACK_TRACE = getStackTrace();
 		
 		#if !flash
-			doErrorStuff(e, path != null, url != null && url != "");		//easy to separately override
+			doErrorStuff(e, path != null && path != "", url != null && url != "");		//easy to separately override
 		#else
 			doErrorStuffByHTTP(e);	//minimal flash error report
 		#end


### PR DESCRIPTION
Also:
Prevent writing to file if no file path is given
Added a trace of the location where the dump file is saved on disk

We could talk about the design decision of implicitly using an url even if none is given (default value of `http://localhost:8080/result`). I prefer using default values resulting in the less possible implicit code. But this is by design, and it's a detail, to be honest. I followed the same design for the file path on disk (default being `./`).

It prevents ```doErrorStuff()``` from writing to disk or sending data to server, depending on the values.

Also, being on mac, I couldn't find the log files, even though there was no error logged that could explain why the file creation aborted or failed. I added a trace with the full path. On mac it goes right into the application bundle.
`APPNAME.app/Contents/Resources/log/errors/` (or something else after Resources if you set a custom path).