### PR TITLE
Don't access internal OpenFL API #if display

### DIFF
--- a/crashdumper/CrashDumper.hx
+++ b/crashdumper/CrashDumper.hx
@@ -192,7 +192,7 @@ class CrashDumper
 		
 		if (Std.is(e, Event))
 		{
-			#if sys
+			#if (sys && !display)
 			@:privateAccess cast(e, Event).__isCanceled = true; //cancel the event. We control exiting from here on out.
 			#end
 		}


### PR DESCRIPTION
This causes issues with code completion in VSCode, because it's unable to build a completion cache as a consequence of accessing a field that doesn't exist in the externs:

    crashdumper/CrashDumper.hx:196: characters 19-46 : openfl.events.Event has no field __isCanceled