### PR TITLE
Added support for Lime 7

### DIFF
--- a/crashdumper/hooks/Util.hx
+++ b/crashdumper/hooks/Util.hx
@@ -4,6 +4,7 @@ import haxe.Http;
 import haxe.io.Bytes;
 import haxe.io.Path;
 import haxe.io.StringInput;
+import haxe.macro.Context;
 
 /**
  * ...
@@ -91,4 +92,17 @@ class Util
 			return "/";
 		#end
 	}
+
+	macro public static function getProjectVersion(path:String) {
+        try {
+            var p = Context.resolvePath(path);
+            var s:String = sys.io.File.getContent(p);
+            var r = new EReg('<\\s?app[^>]*?\\sversion="([.\\d]+)"[^>]*?>', "i");
+            if (r.match(s)) return macro $v{r.matched(1)};
+            else return Context.error('No version found in xml file', Context.currentPos());
+        }
+        catch(e:Dynamic) {
+            return Context.error('Failed to load file $path: $e', Context.currentPos());
+        }
+    }
 }

--- a/crashdumper/hooks/openfl/HookOpenFL.hx
+++ b/crashdumper/hooks/openfl/HookOpenFL.hx
@@ -6,6 +6,7 @@ import haxe.io.Bytes;
 	import openfl.Lib;
 	import openfl.utils.ByteArray;
 	import openfl.events.UncaughtErrorEvent;
+	import crashdumper.hooks.Util;
 #else
 	import nme.Lib;
 	import nme.utils.ByteArray;
@@ -43,10 +44,14 @@ class HookOpenFL implements IHookPlatform
 					fileName = Lib.file;
 					packageName = Lib.packageName;
 					version = Lib.version;
-				#else
+				#elseif (lime < "7.0.0")
 					fileName = Application.current.config.file;
 					packageName = Application.current.config.packageName;
 					version = Application.current.config.version;
+				#else
+					fileName = Application.current.meta.get("file");
+					packageName = Application.current.meta.get("packageName");
+					version = Util.getProjectVersion("project.xml");
 				#end
 			#end
 		#else


### PR DESCRIPTION
Lime 7 [removed](https://lib.haxe.org/p/lime/7.0.0/changelog) `lime.app.config` so I've added conditionals to get the data from `lime.app.meta` when that version is used. Also, the project version number is parsed out of `project.xml` via macro as there is no easy way to access it right now (will probably be fixed in the next OpenFL release).