### PR TITLE
OpenFL Event has stopImmediatePropagation() to cancel an Event, use it.

### DIFF
--- a/crashdumper/CrashDumper.hx
+++ b/crashdumper/CrashDumper.hx
@@ -189,7 +189,11 @@ class CrashDumper
 			doErrorStuffByHTTP(e);	//minimal flash error report
 		#end
 		
-		e.__isCancelled = true;		//cancel the event. We control exiting from here on out.
+		//cancel the event. We control exiting from here on out.
+		if(Std.is(e, openfl.events.Event)) 
+		{
+			e.stopImmediatePropagation();
+		}
 		
 		if (closeOnCrash)
 		{


### PR DESCRIPTION
Tested with OpenFL version 8.4.1

I checked a couple of older versions and the function was there too so I don't think it will break.