### PR TITLE
Fix getFolderPath of HookOpenFL for mobile build

### DIFF
--- a/crashdumper/hooks/openfl/HookOpenFL.hx
+++ b/crashdumper/hooks/openfl/HookOpenFL.hx
@@ -70,9 +70,9 @@ class HookOpenFL implements IHookPlatform
 	{
 		#if (windows || mac || linux || mobile)
 			#if (mobile)
-				if (!Util.isFirstChar(str, "/") && !Util.isFirstChar("\\"))
+				if (!Util.isFirstChar(str, "/") && !Util.isFirstChar(str, "\\"))
 				{
-					str = Util.uCombine("/" + str);
+					str = Util.uCombine(["/", str]);
 				}
 				str = Util.uCombine([SystemPath.applicationStorageDirectory,str]);
 			#else


### PR DESCRIPTION
Function getFolderPath have some wrong function signatures in mobile branch.

When building from master (Haxe 3.4.7 / OpenFL 8.6.4 / Lime 7.1.1 / Windows 10) for android, it gives me the following error: 

![2018-10-29](https://user-images.githubusercontent.com/1065261/47673519-a33a9100-db93-11e8-8302-1ca910b8683e.png)

I fixed it using the other case in the same line then it gives me the following:

![2018-10-29 1](https://user-images.githubusercontent.com/1065261/47673569-bea59c00-db93-11e8-84a4-92e1831eb4c7.png)

The changes in this PR fixes these issues and the build goes fine!