### PR TITLE
Remove deprecation warning from using Haxe versions 4.2 or greater (w…

### DIFF
--- a/crashdumper/CrashDumper.hx
+++ b/crashdumper/CrashDumper.hx
@@ -199,7 +199,7 @@ class CrashDumper
 		#end
 		
 		//cancel the event. We control exiting from here on out.
-		if(Std.is(e, openfl.events.Event)) 
+		if(#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end(e, openfl.events.Event)) 
 		{
 			e.stopImmediatePropagation();
 		}


### PR DESCRIPTION
…ithout breaking backwards compatibility)

I've been using Haxe 4.2.5 recently, and the biggest change is that the function `Std.is` has been renamed `Std.isOfType`, which causes lots of code to throw deprecation warnings. Crashdumper appears to work completely fine, except for this one case!

This solution seems to be the standard one, see e.g. Starling - https://github.com/openfl/starling/commit/f41cce244b78f38ac5c538f922427021ee949545